### PR TITLE
Add recovery init file

### DIFF
--- a/device.mk
+++ b/device.mk
@@ -45,7 +45,7 @@ PRODUCT_COPY_FILES += \
     device/fairphone/fp2/rootdir/fstab.qcom:root/fstab.qcom \
     device/fairphone/fp2/rootdir/fstab.qcom:recovery/root/fstab.qcom \
     device/fairphone/fp2/rootdir/ueventd.qcom.rc:root/ueventd.qcom.rc \
-    device/fairphone/fp2/init.recovery.usb.rc:recovery/root/init.recovery.usb.rc
+    device/fairphone/fp2/rootdir/init.recovery.usb.rc:recovery/root/init.recovery.usb.rc
 
 # WiFi WCNSS configurations
 PRODUCT_COPY_FILES += \

--- a/device.mk
+++ b/device.mk
@@ -44,7 +44,8 @@ PRODUCT_PACKAGES += \
 PRODUCT_COPY_FILES += \
     device/fairphone/fp2/rootdir/fstab.qcom:root/fstab.qcom \
     device/fairphone/fp2/rootdir/fstab.qcom:recovery/root/fstab.qcom \
-    device/fairphone/fp2/rootdir/ueventd.qcom.rc:root/ueventd.qcom.rc
+    device/fairphone/fp2/rootdir/ueventd.qcom.rc:root/ueventd.qcom.rc \
+    device/fairphone/fp2/init.recovery.usb.rc:recovery/root/init.recovery.usb.rc
 
 # WiFi WCNSS configurations
 PRODUCT_COPY_FILES += \

--- a/rootdir/init.recovery.usb.rc
+++ b/rootdir/init.recovery.usb.rc
@@ -1,0 +1,39 @@
+on fs
+    write /sys/class/android_usb/android0/enable 0
+    write /sys/class/android_usb/android0/idVendor 18D1
+    write /sys/class/android_usb/android0/idProduct 4EE2
+    write /sys/class/android_usb/android0/f_ffs/aliases adb
+    write /sys/class/android_usb/android0/functions mtp,adb
+    write /sys/class/android_usb/android0/iManufacturer ${ro.product.manufacturer}
+    write /sys/class/android_usb/android0/iProduct ${ro.product.model}
+    write /sys/class/android_usb/android0/iSerial ${ro.serialno}
+
+on property:sys.storage.ums_enabled=1
+    write /sys/class/android_usb/android0/enable 0
+    write /sys/class/android_usb/android0/functions mass_storage,adb
+    write /sys/class/android_usb/android0/enable 1
+
+on property:sys.storage.ums_enabled=0
+    write /sys/class/android_usb/android0/enable 0
+    write /sys/class/android_usb/android0/functions ${sys.usb.config}
+    write /sys/class/android_usb/android0/enable ${service.adb.root}
+
+on property:sys.usb.config=none
+    stop adbd
+    write /sys/class/android_usb/android0/enable 0
+    write /sys/class/android_usb/android0/bDeviceClass 0
+
+on property:sys.usb.config=mtp,adb
+    stop adbd
+    write /sys/class/android_usb/android0/enable 0
+    write /sys/class/android_usb/android0/functions mtp,adb
+    write /sys/class/android_usb/android0/enable 1
+    start adbd
+
+on property:sys.usb.config=adb
+    stop adbd
+    write /sys/class/android_usb/android0/enable 0
+    write /sys/class/android_usb/android0/functions adb
+    write /sys/class/android_usb/android0/enable ${service.adb.root}
+    start adbd
+


### PR DESCRIPTION
This recovery init file (`init.recovery.usb.rc`) allows the recovery to boot. I also removed the fstab in `out/recovery/root` because it's copied automatically from `out/root`