### PR TITLE
SIM & Network changes

### DIFF
--- a/BoardConfig.mk
+++ b/BoardConfig.mk
@@ -156,6 +156,7 @@ TARGET_POWERHAL_VARIANT := qcom
 AUDIO_FEATURE_ENABLED_FM_POWER_OPT := true
 BOARD_HAVE_QCOM_FM := true
 TARGET_FM_LEGACY_PATCHLOADER := true
+KERNEL_HAS_FINIT_MODULE := false
 
 -include vendor/fairphone/FP2/BoardConfigVendor.mk
 

--- a/FP2.mk
+++ b/FP2.mk
@@ -212,8 +212,8 @@ PRODUCT_PACKAGES += \
 # FM radio
 PRODUCT_PACKAGES += \
     FM2 \
-    qcom.fmradio
-
+    qcom.fmradio \
+    init.qcom.fm.sh
 # Camera
 PRODUCT_PACKAGES += \
     Snap

--- a/overlay/frameworks/base/core/res/res/values/config.xml
+++ b/overlay/frameworks/base/core/res/res/values/config.xml
@@ -305,9 +305,6 @@
     <!-- Enable doze powersaving -->
     <bool name="config_enableAutoPowerModes">true</bool>
 
-    <!-- Our modem doesn't support this query yet -->
-    <string name="config_radio_access_family">GPRS|EDGE|UMTS|HSDPA|HSUPA|HSPA|LTE|HSPAP|GSM|TD_SCDMA|WCDMA|LTE_CA</string>
-
     <!-- Operating voltage for bluetooth controller. 0 by default-->
     <integer translatable="false" name="config_bluetooth_operating_voltage_mv">3700</integer>
 

--- a/overlay/frameworks/base/core/res/res/values/config.xml
+++ b/overlay/frameworks/base/core/res/res/values/config.xml
@@ -343,4 +343,6 @@
     <!-- Operating voltage for bluetooth controller. 0 by default-->
     <integer translatable="false" name="config_bluetooth_operating_voltage_mv">3700</integer>
 
+    <!-- Configuration to support SIM contact batch operation -->
+    <bool name="config_sim_phonebook_batch_operation">false</bool>
 </resources>

--- a/overlay/frameworks/base/core/res/res/values/config.xml
+++ b/overlay/frameworks/base/core/res/res/values/config.xml
@@ -37,10 +37,6 @@
          autodetected from the Configuration. -->
     <bool name="config_showNavigationBar">true</bool>
 
-        <!-- The duration (in milliseconds) that the radio will scan for a signal
-         when there's no network connection. If the scan doesn't timeout, use zero -->
-    <integer name="config_radioScanningTimeout">0</integer>
-
     <!-- Boolean indicating whether the wifi chipset has dual frequency band support -->
     <bool translatable="false" name="config_wifi_dual_band_support">true</bool>
 
@@ -134,9 +130,6 @@
     <!-- Set to true to add links to Cell Broadcast app from Settings and MMS app. -->
     <bool name="config_cellBroadcastAppLinks">true</bool>
 
-    <!-- Make things go fast -->
-    <bool name="config_ui_enableFadingMarquee">false</bool>
-
     <!-- Set to true if the wifi display supports compositing content stored
          in gralloc protected buffers.  For this to be true, there must exist
          a protected hardware path for surface flinger to composite and send
@@ -156,9 +149,6 @@
     -->
 
     <!-- Device specific options -->
-
-    <!-- Default LED on time for notification LED in milliseconds. -->
-    <integer name="config_defaultNotificationLedOn">500</integer>
 
     <!-- Default LED off time for notification LED in milliseconds. -->
     <integer name="config_defaultNotificationLedOff">5000</integer>
@@ -191,9 +181,6 @@
 
     <!-- Is the device capable of hot swapping an ICC Card -->
     <bool name="config_hotswapCapable">true</bool>
-
-    <!-- Flag specifying whether VoLTE & VT is availasble on device -->
-    <bool name="config_device_volte_available">false</bool>
 
     <!--  Maximum number of supported users -->
     <integer name="config_multiuserMaximumUsers">4</integer>
@@ -251,22 +238,6 @@
          The user is forbidden from setting the brightness below this level. -->
     <integer name="config_screenBrightnessSettingMinimum">2</integer>
 
-    <!-- Maximum screen brightness allowed by the power manager.
-         The user is forbidden from setting the brightness above this level. -->
-    <integer name="config_screenBrightnessSettingMaximum">255</integer>
-
-    <!-- Default screen brightness setting.
-         Must be in the range specified by minimum and maximum. -->
-    <integer name="config_screenBrightnessSettingDefault">102</integer>
-
-    <!-- Screen brightness used to dim the screen when the user activity
-         timeout expires.  May be less than the minimum allowed brightness setting
-         that can be set by the user. -->
-    <integer name="config_screenBrightnessDim">10</integer>
-
-    <!-- Default color for notification LED is white. -->
-    <color name="config_defaultNotificationColor">#ffffffff</color>
-
     <!-- Indicate the device's Smart Cover coordinates.
          If none are provided, then the feature will be disabled.
          The array should contain 4 values, in pixels, (sample values provided):
@@ -312,9 +283,6 @@
     <integer name="config_screenBrightnessDoze">5</integer>
     <bool name="config_dozeAfterScreenOff">true</bool>
     <bool name="config_powerDecoupleInteractiveModeFromDisplay">true</bool>
-
-    <!-- Whether device supports double tap to wake -->
-    <bool name="config_supportDoubleTapWake">true</bool>
 
     <string-array name="config_mobile_tcp_buffers">
         <item>"lte:2097152,4194304,8388608,262144,524288,1048576"</item>

--- a/overlay/packages/services/Telephony/res/values/config.xml
+++ b/overlay/packages/services/Telephony/res/values/config.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Copyright (C) 2014 The CyanogenMod Project
+
+     Licensed under the Apache License, Version 2.0 (the "License");
+     you may not use this file except in compliance with the License.
+     You may obtain a copy of the License at
+
+          http://www.apache.org/licenses/LICENSE-2.0
+
+     Unless required by applicable law or agreed to in writing, software
+     distributed under the License is distributed on an "AS IS" BASIS,
+     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     See the License for the specific language governing permissions and
+     limitations under the License.
+-->
+
+<resources>
+
+    <!-- Determine whether calls to mute the microphone in PhoneUtils
+                  are routed through the android.media.AudioManager class (true) or through
+         the com.android.internal.telephony.Phone interface (false). -->
+    <bool name="send_mic_mute_to_AudioManager">true</bool>
+
+    <!-- Show enabled lte option for lte device -->
+    <bool name="config_enabled_lte" translatable="false">true</bool>
+
+    <bool name="allow_emergency_numbers_in_call_log">true</bool>
+
+</resources>

--- a/proprietary-files-qc.txt
+++ b/proprietary-files-qc.txt
@@ -154,3 +154,6 @@ etc/firmware/venus.b03
 etc/firmware/venus.b04
 etc/firmware/venus.mbn
 etc/firmware/venus.mdt
+
+# FM radio
+bin/fm_qsoc_patches

--- a/root/Android.mk
+++ b/root/Android.mk
@@ -10,6 +10,13 @@ LOCAL_MODULE_CLASS := ETC
 LOCAL_SRC_FILES    := init.qcom.bt.sh
 include $(BUILD_PREBUILT)
 
+include $(CLEAR_VARS)
+LOCAL_MODULE       := init.qcom.fm.sh
+LOCAL_MODULE_TAGS  := optional
+LOCAL_MODULE_CLASS := ETC
+LOCAL_SRC_FILES    := init.qcom.fm.sh
+include $(BUILD_PREBUILT)
+
 # Device init files
 
 include $(CLEAR_VARS)

--- a/root/init.qcom.fm.sh
+++ b/root/init.qcom.fm.sh
@@ -1,0 +1,106 @@
+#!/system/bin/sh
+# Copyright (c) 2009-2011, The Linux Foundation. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#     * Redistributions of source code must retain the above copyright
+#       notice, this list of conditions and the following disclaimer.
+#     * Redistributions in binary form must reproduce the above copyright
+#       notice, this list of conditions and the following disclaimer in the
+#       documentation and/or other materials provided with the distribution.
+#     * Neither the name of The Linux Foundation nor
+#       the names of its contributors may be used to endorse or promote
+#       products derived from this software without specific prior written
+#       permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+# NON-INFRINGEMENT ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+# CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+# EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+# PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+# OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+# WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+# OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+# ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+
+setprop hw.fm.init 0
+
+mode=`getprop hw.fm.mode`
+version=`getprop hw.fm.version`
+isAnalog=`getprop hw.fm.isAnalog`
+
+#find the transport type
+TRANSPORT=`getprop ro.qualcomm.bt.hci_transport`
+
+LOG_TAG="qcom-fm"
+LOG_NAME="${0}:"
+
+loge ()
+{
+  /system/bin/log -t $LOG_TAG -p e "$LOG_NAME $@"
+}
+
+logi ()
+{
+  /system/bin/log -t $LOG_TAG -p i "$LOG_NAME $@"
+}
+
+failed ()
+{
+  loge "$1: exit code $2"
+  exit $2
+}
+
+logi "In FM shell Script"
+logi "mode: $mode"
+logi "isAnalog: $isAnalog"
+logi "Transport : $TRANSPORT"
+logi "Version : $version"
+
+#$fm_qsoc_patches <fm_chipVersion> <enable/disable WCM>
+#
+case $mode in
+  "normal")
+    case $TRANSPORT in
+    "smd")
+        logi "inserting the radio transport module"
+        /system/bin/insmod /system/lib/modules/radio-iris-transport.ko
+     ;;
+     *)
+        logi "default transport case "
+     ;;
+    esac
+      /system/bin/fm_qsoc_patches $version 0
+     ;;
+  "wa_enable")
+   /system/bin/fm_qsoc_patches $version 1
+     ;;
+  "wa_disable")
+   /system/bin/fm_qsoc_patches $version 2
+     ;;
+  "config_dac")
+   /system/bin/fm_qsoc_patches $version 3 $isAnalog
+     ;;
+   *)
+    logi "Shell: Default case"
+    /system/bin/fm_qsoc_patches $version 0
+    ;;
+esac
+
+exit_code_fm_qsoc_patches=$?
+
+case $exit_code_fm_qsoc_patches in
+   0)
+	logi "FM QSoC calibration and firmware download succeeded"
+   ;;
+  *)
+	failed "FM QSoC firmware download and/or calibration failed" $exit_code_fm_qsoc_patches
+   ;;
+esac
+
+setprop hw.fm.init 1
+
+exit 0

--- a/root/init.qcom.rc
+++ b/root/init.qcom.rc
@@ -434,3 +434,10 @@ service loc_launcher /system/bin/loc_launcher
     #loc_launcher will start as root and set its uid to gps
     class late_start
     group gps inet net_raw diag qcom_diag net_admin wifi
+
+service fm_dl /system/bin/sh /system/etc/init.qcom.fm.sh
+    class late_start
+    user root
+    group system
+    disabled
+    oneshot

--- a/root/ueventd.qcom.rc
+++ b/root/ueventd.qcom.rc
@@ -45,7 +45,7 @@
 #permissions for CSVT
 /dev/smd11                0660   radio      radio
 
-/dev/radio0               0640   system     system
+/dev/radio0               0640   fm_radio   fm_radio
 /dev/rfcomm0              0660   bluetooth  bluetooth
 /dev/smdcntl0             0640   radio      radio
 /dev/smdcntl1             0640   radio      radio

--- a/system.prop
+++ b/system.prop
@@ -93,6 +93,7 @@ ro.hwui.texture_cache_size=72
 
 # Radio
 DEVICE_PROVISIONED=1
+persist.radio.apm_sim_not_pwdn=1
 persist.radio.multisim.config=dsds
 persist.rild.nitz_long_ons_0=
 persist.rild.nitz_long_ons_1=
@@ -106,8 +107,7 @@ persist.rild.nitz_short_ons_3=
 rild.libargs=-d /dev/smd0
 rild.libpath=/vendor/lib/libril-qc-qmi-1.so
 # Start in global mode
-ro.telephony.default_network=9
-telephony.lteOnCdmaDevice=1
+ro.telephony.default_network=9,9
 telephony.lteOnGsmDevice=1
 
 # Network


### PR DESCRIPTION
@chrmhoffmann posted a new release on the FP forum (https://forum.fairphone.com/t/porting-lineageos-to-fp2/27530/82). Let's get these changes in here as well.

"Changelog:
- Removed "double tap"
- Selection of LTE/4G in network settings fixed
- SIM contacts import should work now (export is not supported currently in Lineage)
- SIM card requested PIN code after flight mode fixed."